### PR TITLE
Create subnet in correct fabric

### DIFF
--- a/src/maasserver/models/interface.py
+++ b/src/maasserver/models/interface.py
@@ -891,7 +891,7 @@ class Interface(CleanSave, TimestampedModel):
                     # so that the user gets a chance to configure it. Note,
                     # however, that if this is already a managed cluster
                     # interface, a Fabric/VLAN will already have been created.
-                    subnet = Subnet.objects.create_from_cidr(cidr)
+                    subnet = Subnet.objects.create_from_cidr(cidr, vlan=self.vlan)
                     maaslog.info(
                         f"Creating subnet {cidr} connected to interface "
                         f"{self} of node {self.get_node()}."


### PR DESCRIPTION
There is a use case:
- MAAS's DHCP is disabled, and an external DHCP sever is used for PXE boot.
- MAAS has 2 nics, named nic1, nic2. The nic2 is actually the one used for provisioning.
- MAAS based on the nic name order, created fabric-0, fabric-1 for them respectively. The fabric-1 is actually the one used for provisioning, while default fabric is fabric-0 which is almost usless.
- Commission a node, the node get an ip, the node UI shows its IP as "Auto assigned". 
- MAAS detected the ip is bound coming from nic2 so it set the node's fabric=1 (more precisely, set vlan_id = id of untagged vlan of fabric-1)
- MAAS found the ip is not belonging to any existing subnets, so it automatically create a subnet, but it always create the subnet on fabric-0.  This is the begining of all wrong things later.
- Deploy the node, also succeeded, when finished, it is node UI shows ip correctly
- Release the node, then the node status shows "Node must be attached to a network", this is because it could not find a proper subnet in fabric-1.
- The node become unavailable for Deploying unless Commission again.

So this PR create such discovered subnet in correct fabric.